### PR TITLE
Add API schema and FastAPI skeleton

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,12 @@
+# Backend
+
+This directory contains the FastAPI application. It uses SQLite as a simple storage backend.
+
+Run the development server with:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+The API schema is documented in `../docs/api_schema.md`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI, HTTPException
+from typing import List
+from .models import PuzzleSet, Puzzle, MoveRequest, MoveResult, SessionSummary
+
+app = FastAPI(title="Woodpecker API")
+
+# In-memory placeholders
+PUZZLE_SETS = [
+    PuzzleSet(id=1, name="Intro", description="Mate in one")
+]
+PUZZLES = [
+    Puzzle(id=42, puzzle_set_id=1, fen="8/8/8/8/8/8/8/8 w - - 0 1", moves_count=1)
+]
+
+SESSIONS = {}
+
+@app.get("/api/puzzle_sets", response_model=List[PuzzleSet])
+def list_puzzle_sets():
+    return PUZZLE_SETS
+
+@app.post("/api/sessions", status_code=201)
+def start_session(data: dict):
+    puzzle_set_id = data.get("puzzle_set_id")
+    if not puzzle_set_id:
+        raise HTTPException(status_code=400, detail="puzzle_set_id required")
+    session_id = f"s{len(SESSIONS)+1}"
+    SESSIONS[session_id] = {"index": 0, "score": 0}
+    puzzle = PUZZLES[0]
+    return {
+        "id": session_id,
+        "puzzle": puzzle,
+        "score": 0,
+        "elapsed_seconds": 0,
+    }
+
+@app.get("/api/sessions/{session_id}/puzzle", response_model=Puzzle)
+def get_puzzle(session_id: str):
+    if session_id not in SESSIONS:
+        raise HTTPException(status_code=404, detail="session not found")
+    return PUZZLES[SESSIONS[session_id]["index"]]
+
+@app.post("/api/sessions/{session_id}/move", response_model=MoveResult)
+def submit_move(session_id: str, move: MoveRequest):
+    if session_id not in SESSIONS:
+        raise HTTPException(status_code=404, detail="session not found")
+    # Simplified check: always correct if move is 'e2e4'
+    correct = move.move == "e2e4"
+    session = SESSIONS[session_id]
+    if correct:
+        session["score"] += 1
+        session["index"] += 1
+        puzzle_solved = True
+    else:
+        puzzle_solved = False
+    return MoveResult(correct=correct, puzzle_solved=puzzle_solved, score=session["score"])
+
+@app.get("/api/sessions/{session_id}/summary", response_model=SessionSummary)
+def summary(session_id: str):
+    if session_id not in SESSIONS:
+        raise HTTPException(status_code=404, detail="session not found")
+    session = SESSIONS[session_id]
+    return SessionSummary(score=session["score"], elapsed_seconds=0)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class PuzzleSet(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+
+class Puzzle(BaseModel):
+    id: int
+    puzzle_set_id: int
+    fen: str
+    moves_count: int
+
+class MoveRequest(BaseModel):
+    move: str
+
+class MoveResult(BaseModel):
+    correct: bool
+    puzzle_solved: bool
+    score: int
+    solution: Optional[List[str]] = None
+
+class SessionSummary(BaseModel):
+    score: int
+    elapsed_seconds: int

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+SQLAlchemy
+pydantic

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -1,0 +1,90 @@
+# API Schema for Woodpecker Training App
+
+This document describes the REST API that the React frontend and FastAPI backend should use. All endpoints are prefixed with `/api`.
+
+## Models
+
+### PuzzleSet
+- `id` (integer): unique identifier
+- `name` (string): display name
+- `description` (string): optional description
+
+### Puzzle
+- `id` (integer): unique identifier
+- `puzzle_set_id` (integer): ID of the set it belongs to
+- `fen` (string): board position in FEN notation
+- `moves_count` (integer): number of moves in the solution
+
+### Session
+- `id` (string): unique session identifier
+- `puzzle_set_id` (integer): puzzle set in use
+- `start_time` (ISO 8601 timestamp)
+- `score` (integer)
+- `elapsed_seconds` (integer)
+
+## Endpoints
+
+### `GET /api/puzzle_sets`
+Returns the list of available puzzle sets.
+
+**Response 200**
+```json
+[
+  {"id": 1, "name": "Intro", "description": "Mate in one"}
+]
+```
+
+### `POST /api/sessions`
+Start a new training session with a puzzle set.
+
+**Request body**
+```json
+{"puzzle_set_id": 1}
+```
+
+**Response 201**
+```json
+{"id": "abc123", "puzzle": {"id": 42, "fen": "...", "moves_count": 3}, "score": 0, "elapsed_seconds": 0}
+```
+
+### `GET /api/sessions/{session_id}/puzzle`
+Fetch the current puzzle for the session.
+
+**Response 200**
+```json
+{"id": 42, "fen": "...", "moves_count": 3}
+```
+
+### `POST /api/sessions/{session_id}/move`
+Submit the next move for the current puzzle.
+
+**Request body**
+```json
+{"move": "e2e4"}
+```
+
+**Response 200** (correct move)
+```json
+{"correct": true, "puzzle_solved": false, "score": 1}
+```
+
+**Response 200** (incorrect move)
+```json
+{"correct": false, "puzzle_solved": false, "score": 0, "solution": ["e2e4", "e7e5"]}
+```
+
+If `puzzle_solved` becomes `true`, the next call to `GET /api/sessions/{session_id}/puzzle` returns the next puzzle or `null` when finished.
+
+### `GET /api/sessions/{session_id}/summary`
+Return final score and timing once the session ends.
+
+**Response 200**
+```json
+{"score": 7, "elapsed_seconds": 300}
+```
+
+## Notes
+- All timestamps use ISO 8601 format (UTC).
+- Moves are in UCI format (`e2e4`). The frontend should convert from chessboard clicks to this format.
+- Authentication is not yet implemented; sessions are anonymous.
+- The schema may evolve but should remain backward compatible when possible.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend
+
+The frontend will be a React application.
+
+During development, run the backend locally (see `../backend/README.md`) and proxy API requests to it. Use the API schema in `../docs/api_schema.md` when implementing components.


### PR DESCRIPTION
## Summary
- document REST API endpoints and models
- scaffold FastAPI backend with example in-memory data
- add backend & frontend readmes with setup guidance

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1695c8448325aa08132454eeb70a