### PR TITLE
Add interactive solution viewer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,33 @@ import axios from 'axios';
 import { Chess } from 'chess.js';
 import { Chessboard } from 'react-chessboard';
 
+function ArrowOverlay({ move, boardWidth }) {
+  if (!move) return null;
+  const squareSize = boardWidth / 8;
+  const fromFile = move.slice(0, 1).charCodeAt(0) - 'a'.charCodeAt(0);
+  const fromRank = parseInt(move[1], 10) - 1;
+  const toFile = move.slice(2, 3).charCodeAt(0) - 'a'.charCodeAt(0);
+  const toRank = parseInt(move[3], 10) - 1;
+  const x1 = (fromFile + 0.5) * squareSize;
+  const y1 = boardWidth - (fromRank + 0.5) * squareSize;
+  const x2 = (toFile + 0.5) * squareSize;
+  const y2 = boardWidth - (toRank + 0.5) * squareSize;
+  return (
+    <svg
+      width={boardWidth}
+      height={boardWidth}
+      style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
+    >
+      <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
+          <polygon points="0 0, 10 3.5, 0 7" fill="red" />
+        </marker>
+      </defs>
+      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="red" strokeWidth="4" markerEnd="url(#arrowhead)" />
+    </svg>
+  );
+}
+
 function App() {
   const [puzzleSets, setPuzzleSets] = useState([]);
   const [selectedSet, setSelectedSet] = useState('');
@@ -14,6 +41,9 @@ function App() {
   const [timerId, setTimerId] = useState(null);
   const [summary, setSummary] = useState(null);
   const [boardWidth, setBoardWidth] = useState(Math.min(480, window.innerWidth - 20));
+  const [showSolution, setShowSolution] = useState(false);
+  const [solutionMoves, setSolutionMoves] = useState([]);
+  const [solutionIndex, setSolutionIndex] = useState(0);
 
   useEffect(() => {
     const handleResize = () => {
@@ -51,12 +81,43 @@ function App() {
     if (res.data) {
       setPuzzle(res.data);
       setChess(new Chess(res.data.fen));
+      setShowSolution(false);
+      setSolutionMoves([]);
+      setSolutionIndex(0);
     } else {
       const summaryRes = await axios.get(`/api/sessions/${session}/summary`);
       setSummary(summaryRes.data);
       clearInterval(timerId);
     }
   };
+
+  const stepForward = () => {
+    if (solutionIndex >= solutionMoves.length) return;
+    const c = new Chess(chess.fen());
+    c.move(solutionMoves[solutionIndex]);
+    setChess(c);
+    setSolutionIndex(solutionIndex + 1);
+  };
+
+  const stepBackward = () => {
+    if (solutionIndex === 0) return;
+    const c = new Chess(puzzle.fen);
+    for (let i = 0; i < solutionIndex - 1; i++) {
+      c.move(solutionMoves[i]);
+    }
+    setChess(c);
+    setSolutionIndex(solutionIndex - 1);
+  };
+
+  useEffect(() => {
+    const handleKey = e => {
+      if (!showSolution) return;
+      if (e.key === 'ArrowRight') stepForward();
+      if (e.key === 'ArrowLeft') stepBackward();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [showSolution, solutionIndex, solutionMoves, chess, puzzle]);
 
   const onDrop = async (sourceSquare, targetSquare) => {
     const move = chess.move({ from: sourceSquare, to: targetSquare, promotion: 'q' });
@@ -69,9 +130,13 @@ function App() {
     if (!res.data.correct) {
       alert('Incorrect!');
       if (res.data.solution) {
-        alert('Solution: ' + res.data.solution.join(', '));
+        setShowSolution(true);
+        setSolutionMoves(res.data.solution);
+        setSolutionIndex(0);
+        setChess(new Chess(puzzle.fen));
+      } else {
+        await fetchNextPuzzle();
       }
-      await fetchNextPuzzle();
       return true;
     }
 
@@ -108,12 +173,35 @@ function App() {
   }
 
   return (
-    <div style={{ padding: '1rem' }}>
-      <div style={{ marginBottom: '1rem' }}>
-        <span>Score: {score}</span> | <span>Time: {elapsed}s</span> |
-        <span>{chess.turn() === 'w' ? 'White' : 'Black'} to move</span>
+    <div style={{ padding: '1rem', display: 'flex' }}>
+      <div>
+        <div style={{ marginBottom: '1rem' }}>
+          <span>Score: {score}</span> | <span>Time: {elapsed}s</span> |
+          <span>{chess.turn() === 'w' ? 'White' : 'Black'} to move</span>
+        </div>
+        <div style={{ position: 'relative', width: boardWidth }}>
+          <Chessboard
+            boardWidth={boardWidth}
+            position={chess.fen()}
+            onPieceDrop={showSolution ? undefined : onDrop}
+            arePiecesDraggable={!showSolution}
+          />
+          {showSolution && (
+            <ArrowOverlay
+              move={solutionIndex < solutionMoves.length ? solutionMoves[solutionIndex] : null}
+              boardWidth={boardWidth}
+            />
+          )}
+        </div>
       </div>
-      <Chessboard boardWidth={boardWidth} position={chess.fen()} onPieceDrop={onDrop} />
+      {showSolution && (
+        <div style={{ marginLeft: '1rem', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <button onClick={stepBackward} disabled={solutionIndex === 0}>{'<'}</button>
+          <div style={{ margin: '0.5rem 0' }}>{solutionIndex}/{solutionMoves.length}</div>
+          <button onClick={stepForward} disabled={solutionIndex === solutionMoves.length}>{'>'}</button>
+          <button onClick={fetchNextPuzzle} style={{ marginTop: '1rem' }}>Next Puzzle</button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `ArrowOverlay` helper to draw arrows on the chessboard
- step through solution moves with keyboard or buttons
- disable piece dragging while showing solution
- show navigation controls next to the board and a `Next Puzzle` button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bcdd227b08325b4036fdf038c456b