### PR TITLE
Autoplay opponent moves

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,15 +76,25 @@ def submit_move(session_id: str, move: MoveRequest):
 
     if move.move == expected:
         move_idx += 1
-        session["move_index"] = move_idx
+        next_move = None
         if move_idx == len(solution):
             session["score"] += 1
             session["index"] += 1
             session["move_index"] = 0
             puzzle_solved = True
         else:
-            puzzle_solved = False
-        return MoveResult(correct=True, puzzle_solved=puzzle_solved, score=session["score"])
+            # autoplay opponent move
+            next_move = solution[move_idx]
+            move_idx += 1
+            if move_idx == len(solution):
+                session["score"] += 1
+                session["index"] += 1
+                session["move_index"] = 0
+                puzzle_solved = True
+            else:
+                session["move_index"] = move_idx
+                puzzle_solved = False
+        return MoveResult(correct=True, puzzle_solved=puzzle_solved, score=session["score"], next_move=next_move)
     else:
         # Wrong answer: reveal solution and move to next puzzle
         session["index"] += 1

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -19,6 +19,7 @@ class MoveResult(BaseModel):
     correct: bool
     puzzle_solved: bool
     score: int
+    next_move: Optional[str] = None
     solution: Optional[List[str]] = None
 
 class SessionSummary(BaseModel):

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -65,8 +65,9 @@ Submit the next move for the current puzzle.
 
 **Response 200** (correct move)
 ```json
-{"correct": true, "puzzle_solved": false, "score": 1}
+{"correct": true, "puzzle_solved": false, "score": 1, "next_move": "e7e5"}
 ```
+`next_move` contains the automatically played reply when the puzzle is not yet solved.
 
 **Response 200** (incorrect move)
 ```json

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -151,6 +151,12 @@ function App() {
       return true;
     }
 
+    if (res.data.next_move) {
+      const c = new Chess(chess.fen());
+      c.move(res.data.next_move);
+      setChess(c);
+    }
+
     if (res.data.puzzle_solved) {
       await fetchNextPuzzle();
     }


### PR DESCRIPTION
## Summary
- autoplay the opponent move after a correct answer
- record the next move in the API response
- document the new field in the API schema
- update the frontend to apply the opponent move automatically

## Testing
- `npm test --prefix frontend`
- `pytest` *(runs zero tests)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd17ca9d08325a4cf2e3507c2ad15