### PR TITLE
Fix arrow overlay position

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,7 +27,7 @@ function ArrowOverlay({ move, boardWidth, orientation }) {
     >
       <defs>
         <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
-          <polygon points="0 0, 10 3.5, 0 7" fill="red" />
+          <polygon points="-10 0, 0 3.5, -10 7" fill="red" />
         </marker>
       </defs>
       <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="red" strokeWidth="4" markerEnd="url(#arrowhead)" />


### PR DESCRIPTION
## Summary
- fix arrow overlay to align arrow tip with destination square center

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd52697f88325959340bb93a2fefe