### PR TITLE
Handle puzzles with opponent first move

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,8 +49,10 @@ def start_session(data: dict):
     if not puzzle_set_id:
         raise HTTPException(status_code=400, detail="puzzle_set_id required")
     session_id = f"s{len(SESSIONS)+1}"
-    SESSIONS[session_id] = {"index": 0, "score": 0, "move_index": 0}
+    SESSIONS[session_id] = {"index": 0, "score": 0, "move_index": 1}
     puzzle = PUZZLES[0]
+    first_move = PUZZLE_SOLUTIONS[puzzle.id][0]
+    puzzle = Puzzle(**puzzle.dict(), initial_move=first_move)
     return {
         "id": session_id,
         "puzzle": puzzle,
@@ -62,7 +64,13 @@ def start_session(data: dict):
 def get_puzzle(session_id: str):
     if session_id not in SESSIONS:
         raise HTTPException(status_code=404, detail="session not found")
-    return PUZZLES[SESSIONS[session_id]["index"]]
+    session = SESSIONS[session_id]
+    if session["index"] >= len(PUZZLES):
+        return None
+    puzzle = PUZZLES[session["index"]]
+    first_move = PUZZLE_SOLUTIONS[puzzle.id][0]
+    session["move_index"] = 1
+    return Puzzle(**puzzle.dict(), initial_move=first_move)
 
 @app.post("/api/sessions/{session_id}/move", response_model=MoveResult)
 def submit_move(session_id: str, move: MoveRequest):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,6 +11,7 @@ class Puzzle(BaseModel):
     puzzle_set_id: int
     fen: str
     moves_count: int
+    initial_move: Optional[str] = None
 
 class MoveRequest(BaseModel):
     move: str

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -14,6 +14,8 @@ This document describes the REST API that the React frontend and FastAPI backend
 - `puzzle_set_id` (integer): ID of the set it belongs to
 - `fen` (string): board position in FEN notation
 - `moves_count` (integer): number of moves in the solution
+- `initial_move` (string, optional): move automatically played before the user
+  moves
 
 ### Session
 - `id` (string): unique session identifier
@@ -44,7 +46,7 @@ Start a new training session with a puzzle set.
 
 **Response 201**
 ```json
-{"id": "abc123", "puzzle": {"id": 42, "fen": "...", "moves_count": 3}, "score": 0, "elapsed_seconds": 0}
+{"id": "abc123", "puzzle": {"id": 42, "fen": "...", "moves_count": 3, "initial_move": "e7e5"}, "score": 0, "elapsed_seconds": 0}
 ```
 
 ### `GET /api/sessions/{session_id}/puzzle`
@@ -52,7 +54,7 @@ Fetch the current puzzle for the session.
 
 **Response 200**
 ```json
-{"id": 42, "fen": "...", "moves_count": 3}
+{"id": 42, "fen": "...", "moves_count": 3, "initial_move": "e7e5"}
 ```
 
 ### `POST /api/sessions/{session_id}/move`
@@ -87,5 +89,7 @@ Return final score and timing once the session ends.
 ## Notes
 - All timestamps use ISO 8601 format (UTC).
 - Moves are in UCI format (`e2e4`). The frontend should convert from chessboard clicks to this format.
+- The first move in each puzzle is played automatically by the backend. The
+  client should apply the `initial_move` before allowing the user to move.
 - Authentication is not yet implemented; sessions are anonymous.
 - The schema may evolve but should remain backward compatible when possible.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,8 +52,10 @@ function App() {
   const [solutionIndex, setSolutionIndex] = useState(0);
   const [puzzleSolved, setPuzzleSolved] = useState(false);
 
+  // After loading a puzzle we automatically play the first move from the
+  // solution. Orientation should therefore be for the side that moves second.
   const orientationFromFen = fen =>
-    fen.split(' ')[1] === 'w' ? 'white' : 'black';
+    fen.split(' ')[1] === 'w' ? 'black' : 'white';
 
   useEffect(() => {
     const handleResize = () => {
@@ -83,7 +85,11 @@ function App() {
     setPuzzle(res.data.puzzle);
     setScore(res.data.score);
     setElapsed(res.data.elapsed_seconds);
-    setChess(new Chess(res.data.puzzle.fen));
+    const c = new Chess(res.data.puzzle.fen);
+    if (res.data.puzzle.initial_move) {
+      c.move(res.data.puzzle.initial_move);
+    }
+    setChess(c);
     setBoardOrientation(orientationFromFen(res.data.puzzle.fen));
     setPuzzleSolved(false);
   };
@@ -93,7 +99,11 @@ function App() {
     const res = await axios.get(`/api/sessions/${session}/puzzle`);
     if (res.data) {
       setPuzzle(res.data);
-      setChess(new Chess(res.data.fen));
+      const c = new Chess(res.data.fen);
+      if (res.data.initial_move) {
+        c.move(res.data.initial_move);
+      }
+      setChess(c);
       setBoardOrientation(orientationFromFen(res.data.fen));
       setShowSolution(false);
       setSolutionMoves([]);


### PR DESCRIPTION
## Summary
- autoplay the opponent's first move when sending a puzzle
- expose that first move as `initial_move`
- invert board orientation after loading a puzzle
- document the new API behaviour

## Testing
- `python -m py_compile backend/app/main.py backend/app/models.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd834fa6c8325a9a393335f33a750