### PR TITLE
Restore original puzzle schema

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,11 +14,6 @@ class Puzzle(BaseModel):
     initial_move: Optional[str] = None
 
 
-class PuzzleProgress(Puzzle):
-    """Puzzle information along with progress data."""
-
-    index: int
-    total: int
 
 class MoveRequest(BaseModel):
     move: str

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -52,9 +52,7 @@ Start a new training session with a puzzle set.
     "id": 42,
     "fen": "...",
     "moves_count": 3,
-    "initial_move": "e7e5",
-    "index": 1,
-    "total": 10
+    "initial_move": "e7e5"
   },
   "score": 0,
   "elapsed_seconds": 0
@@ -70,9 +68,7 @@ Fetch the current puzzle for the session.
   "id": 42,
   "fen": "...",
   "moves_count": 3,
-  "initial_move": "e7e5",
-  "index": 5,
-  "total": 10
+  "initial_move": "e7e5"
 }
 ```
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,8 +52,6 @@ function App() {
   const [solutionIndex, setSolutionIndex] = useState(0);
   const [puzzleSolved, setPuzzleSolved] = useState(false);
   const [lastMove, setLastMove] = useState(null);
-  const [progressIndex, setProgressIndex] = useState(0);
-  const [progressTotal, setProgressTotal] = useState(0);
 
   // After loading a puzzle we automatically play the first move from the
   // solution. Orientation should therefore be for the side that moves second.
@@ -94,8 +92,6 @@ function App() {
     const res = await axios.post('/api/sessions', { puzzle_set_id: parseInt(selectedSet) });
     setSession(res.data.id);
     setPuzzle(res.data.puzzle);
-    setProgressIndex(res.data.puzzle.index);
-    setProgressTotal(res.data.puzzle.total);
     setScore(res.data.score);
     setElapsed(res.data.elapsed_seconds);
     const baseFen = res.data.puzzle.fen;
@@ -120,8 +116,6 @@ function App() {
     const res = await axios.get(`/api/sessions/${session}/puzzle`);
     if (res.data) {
       setPuzzle(res.data);
-      setProgressIndex(res.data.index);
-      setProgressTotal(res.data.total);
       const baseFen = res.data.fen;
       const c = new Chess(baseFen);
       setChess(c);
@@ -289,7 +283,6 @@ function App() {
       <div>
         <div style={{ marginBottom: '1rem' }}>
           <span>Score: {score}</span> | <span>Time: {elapsed}s</span> |
-          <span>Puzzle {progressIndex}/{progressTotal}</span> |
           <span>{chess.turn() === 'w' ? 'White' : 'Black'} to move</span>
         </div>
         <div style={{ position: 'relative', width: boardWidth }}>


### PR DESCRIPTION
## Summary
- remove backend puzzle progress tracking
- drop progress counter display from frontend
- update API docs accordingly

## Testing
- `npm test --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685bf38d2b888325a135416819be808c