### PR TITLE
Display past attempts on initial page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -98,10 +98,9 @@ function App() {
     return () => timerId && clearInterval(timerId);
   }, [session, timerId]);
 
+  // Fetch past performances on load and whenever the summary changes
   useEffect(() => {
-    if (summary) {
-      axios.get('/api/performances').then(r => setPerformances(r.data));
-    }
+    axios.get('/api/performances').then(r => setPerformances(r.data));
   }, [summary]);
 
   const startSession = async () => {
@@ -328,6 +327,31 @@ function App() {
           ))}
         </select>
         <button onClick={startSession} disabled={!selectedSet}>Start</button>
+        {performances.length > 0 && (
+          <div style={{ marginTop: '1rem' }}>
+            <h3>Past Performances</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Set</th>
+                  <th>Score</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {performances.map(p => (
+                  <tr key={p.id}>
+                    <td>{new Date(p.date).toLocaleString()}</td>
+                    <td>{p.puzzle_set}</td>
+                    <td>{p.score}</td>
+                    <td>{p.elapsed_seconds}s</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- fetch past performances on load
- show past results on the start page before a training session begins

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_685c4f334c9083259941b3cdceb25e05