### PR TITLE
Improve performance table UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -287,7 +287,7 @@ function App() {
           {performances.length > 0 && (
             <div style={{ marginTop: '1rem' }}>
               <h3>Past Performances</h3>
-              <table>
+              <table className="performance-table">
                 <thead>
                   <tr>
                     <th>Date</th>
@@ -302,7 +302,7 @@ function App() {
                       key={p.id}
                       style={p.id === summary.performance_id ? { fontWeight: 'bold' } : {}}
                     >
-                      <td>{new Date(p.date).toLocaleString()}</td>
+                      <td>{new Date(p.date).toISOString()}</td>
                       <td>{p.puzzle_set}</td>
                       <td>{p.score}</td>
                       <td>{p.elapsed_seconds}s</td>
@@ -330,7 +330,7 @@ function App() {
         {performances.length > 0 && (
           <div style={{ marginTop: '1rem' }}>
             <h3>Past Performances</h3>
-            <table>
+            <table className="performance-table">
               <thead>
                 <tr>
                   <th>Date</th>
@@ -342,7 +342,7 @@ function App() {
               <tbody>
                 {performances.map(p => (
                   <tr key={p.id}>
-                    <td>{new Date(p.date).toLocaleString()}</td>
+                    <td>{new Date(p.date).toISOString()}</td>
                     <td>{p.puzzle_set}</td>
                     <td>{p.score}</td>
                     <td>{p.elapsed_seconds}s</td>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,3 +34,20 @@ select {
   padding: 0.5rem;
   border-radius: 4px;
 }
+
+table.performance-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.performance-table th,
+.performance-table td {
+  border: 1px solid #555;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.performance-table th {
+  background-color: #222;
+}


### PR DESCRIPTION
## Summary
- format performance history dates using ISO 8601
- add table styling to make columns clearer

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_685c5125ace48325bb85d807fa46b4ae