### PR TITLE
Add opening-based puzzle set generation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,16 +20,23 @@ The API schema is documented in `../docs/api_schema.md`.
 
 ## Generating thematic puzzle sets
 
-If you have the full `lichess_db_puzzle.csv` dataset available you can create additional puzzle sets automatically. The helper script `build_thematic_sets.py` uses **polars** for fast CSV processing and selects puzzles for a few common themes (mate in 1/2/3, endgames, fork tactics and discovered attacks).
+If you have the full `lichess_db_puzzle.csv` dataset available you can create additional puzzle sets automatically. The helper script `build_thematic_sets.py` uses **polars** for fast CSV processing and can generate sets for any theme or opening tag present in the dataset.
 
 ```bash
-python build_thematic_sets.py lichess_db_puzzle.csv --db woodpecker.db --sql init_thematic.sql
+python build_thematic_sets.py lichess_db_puzzle.csv --token mateIn1 --sets 3
 ```
 
-The script updates `woodpecker.db` and also writes the SQL commands used to `init_thematic.sql` so that the same data can be imported later with `sqlite3 woodpecker.db < init_thematic.sql`. Additional options let you control the number of puzzles per set and filter by rating:
+The script updates `woodpecker.db` and also writes the SQL commands used to `init_thematic.sql` so that the same data can be imported later with `sqlite3 woodpecker.db < init_thematic.sql`. Additional options let you control the number of sets, the puzzles per set and filter by rating:
 
 ```bash
-python build_thematic_sets.py lichess_db_puzzle.csv --count 50 --min-rating 1200
+python build_thematic_sets.py lichess_db_puzzle.csv --token endgame --sets 2 --count 50 --min-rating 1200
 ```
 
-This would create sets of 50 puzzles each with a minimum rating of 1200.
+This would create two sets of 50 endgame puzzles with a minimum rating of 1200.
+
+By default the rows are matched against the ``Themes`` column. You can instead
+match against the ``OpeningTags`` column which is present in the full dataset:
+
+```bash
+python build_thematic_sets.py lichess_db_puzzle.csv --token sicilian --column OpeningTags
+```


### PR DESCRIPTION
## Summary
- support generating puzzle sets using `OpeningTags`
- document `--column` option


------
https://chatgpt.com/codex/tasks/task_e_685e652248308325b5a7334e80c99e76