### PR TITLE
Implement hint system with updated scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Features to be implemented:
 - keep the score and time in memory to see progress
 - the solution to a puzzle can contain several moves
 - need a classic chess interface where user can click to set moves
- - if correct, user has positive feedback
-   - if it was the last move of the solution, give user 1 point and show a success message
-   - the user clicks "Next Puzzle" to continue
-   - else wait until next move
+- if correct, user has positive feedback
+  - if it was the last move of the solution, award points based on hint usage (2 without hint, 1 with hint) and show a success message
+  - the user clicks "Next Puzzle" to continue
+  - else wait until next move
 - if incorrect, user has negative feedback, lose one point and can see the solution before clicking to see the next puzzle
 - when the last puzzle is done, display the score summmary
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ General idea
 
 Features to be implemented:
 - choices between different sets of puzzles (some sets are thematic ex endgames)
-- score (+1 for correct -1 for incorrect ) for proposed solutions
+ - score system: +2 when a puzzle is solved without using a hint, +1 when solved after taking a hint and -1 when failed
 - chronometer: the goal is to maximize score and minimize time
 - keep the score and time in memory to see progress
 - the solution to a puzzle can contain several moves

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,11 @@ def get_db():
 SESSIONS = {}
 LAST_RUNS = {}
 
+# Scoring constants
+POINTS_SOLVED_NO_HINT = 2
+POINTS_SOLVED_WITH_HINT = 1
+POINTS_FAILED = -1
+
 @app.get("/api/puzzle_sets", response_model=List[PuzzleSet])
 def list_puzzle_sets(db: Session = Depends(get_db)):
     results = (
@@ -152,7 +157,11 @@ def submit_move(session_id: str, move: MoveRequest):
         move_idx += 1
         next_move = None
         if move_idx == len(solution):
-            session["score"] += 2 if not session.get("hint_used") else 1
+            session["score"] += (
+                POINTS_SOLVED_NO_HINT
+                if not session.get("hint_used")
+                else POINTS_SOLVED_WITH_HINT
+            )
             session["index"] += 1
             session["move_index"] = 0
             session["hint_used"] = False
@@ -162,7 +171,11 @@ def submit_move(session_id: str, move: MoveRequest):
             next_move = solution[move_idx]
             move_idx += 1
             if move_idx == len(solution):
-                session["score"] += 2 if not session.get("hint_used") else 1
+                session["score"] += (
+                    POINTS_SOLVED_NO_HINT
+                    if not session.get("hint_used")
+                    else POINTS_SOLVED_WITH_HINT
+                )
                 session["index"] += 1
                 session["move_index"] = 0
                 session["hint_used"] = False
@@ -173,7 +186,7 @@ def submit_move(session_id: str, move: MoveRequest):
         return MoveResult(correct=True, puzzle_solved=puzzle_solved, score=session["score"], next_move=next_move)
     else:
         # Wrong answer: reveal solution and move to next puzzle
-        session["score"] -= 1
+        session["score"] += POINTS_FAILED
         session["index"] += 1
         session["move_index"] = 0
         session["hint_used"] = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -109,6 +109,7 @@ def start_session(data: dict, db: Session = Depends(get_db)):
         "attempts": attempts,
         "puzzles": puzzles,
         "solutions": solutions,
+        "hint_used": False,
     }
     puzzle = puzzles[0]
     first_move = solutions[puzzle.id][0]
@@ -151,18 +152,20 @@ def submit_move(session_id: str, move: MoveRequest):
         move_idx += 1
         next_move = None
         if move_idx == len(solution):
-            session["score"] += 1
+            session["score"] += 2 if not session.get("hint_used") else 1
             session["index"] += 1
             session["move_index"] = 0
+            session["hint_used"] = False
             puzzle_solved = True
         else:
             # autoplay opponent move
             next_move = solution[move_idx]
             move_idx += 1
             if move_idx == len(solution):
-                session["score"] += 1
+                session["score"] += 2 if not session.get("hint_used") else 1
                 session["index"] += 1
                 session["move_index"] = 0
+                session["hint_used"] = False
                 puzzle_solved = True
             else:
                 session["move_index"] = move_idx
@@ -170,9 +173,31 @@ def submit_move(session_id: str, move: MoveRequest):
         return MoveResult(correct=True, puzzle_solved=puzzle_solved, score=session["score"], next_move=next_move)
     else:
         # Wrong answer: reveal solution and move to next puzzle
+        session["score"] -= 1
         session["index"] += 1
         session["move_index"] = 0
+        session["hint_used"] = False
         return MoveResult(correct=False, puzzle_solved=False, score=session["score"], solution=solution)
+
+
+@app.get("/api/sessions/{session_id}/hint")
+def get_hint(session_id: str):
+    """Return the square of the piece that should be moved next."""
+    if session_id not in SESSIONS:
+        raise HTTPException(status_code=404, detail="session not found")
+    session = SESSIONS[session_id]
+    puzzles = session["puzzles"]
+    solutions = session["solutions"]
+    if session["index"] >= len(puzzles):
+        raise HTTPException(status_code=400, detail="session finished")
+    puzzle = puzzles[session["index"]]
+    move_idx = session.get("move_index", 0)
+    solution = solutions[puzzle.id]
+    if move_idx >= len(solution):
+        raise HTTPException(status_code=400, detail="puzzle solved")
+    session["hint_used"] = True
+    expected = solution[move_idx]
+    return {"square": expected[:2]}
 
 @app.get("/api/sessions/{session_id}/summary", response_model=SessionSummary)
 def summary(session_id: str, db: Session = Depends(get_db)):

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -90,13 +90,22 @@ Submit the next move for the current puzzle.
 
 **Response 200** (correct move)
 ```json
-{"correct": true, "puzzle_solved": false, "score": 1, "next_move": "e7e5"}
+{"correct": true, "puzzle_solved": false, "score": 2, "next_move": "e7e5"}
 ```
 `next_move` contains the automatically played reply when the puzzle is not yet solved.
 
 **Response 200** (incorrect move)
 ```json
-{"correct": false, "puzzle_solved": false, "score": 0, "solution": ["e2e4", "e7e5"]}
+{"correct": false, "puzzle_solved": false, "score": -1, "solution": ["e2e4", "e7e5"]}
+```
+
+### `GET /api/sessions/{session_id}/hint`
+Request the square of the piece that should be moved next. Using this endpoint
+marks the hint as used for the current puzzle.
+
+**Response 200**
+```json
+{"square": "e2"}
 ```
 
 If `puzzle_solved` becomes `true`, the next call to `GET /api/sessions/{session_id}/puzzle` returns the next puzzle or `null` when finished.


### PR DESCRIPTION
## Summary
- implement a hint endpoint on the backend and track hint usage
- award 2 points for puzzles solved without hints, 1 point when a hint was used and -1 on failure
- expose a `Hint` button in the React UI which highlights the piece to move
- update documentation for the new endpoint and scoring rules

## Testing
- `npm test --silent` *(fails: No tests yet)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec3b1da7483258fdbbb13d4cae925