### PR TITLE
Make Next Puzzle button larger

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -499,7 +499,13 @@ function App() {
               </>
             )}
             {(puzzleSolved || showSolution) && (
-              <button onClick={fetchNextPuzzle} style={{ marginTop: '1rem' }}>Next Puzzle</button>
+              <button
+                onClick={fetchNextPuzzle}
+                className="next-puzzle-button"
+                style={{ marginTop: '1rem' }}
+              >
+                Next Puzzle
+              </button>
             )}
           </div>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,3 +51,8 @@ table.performance-table {
 .performance-table th {
   background-color: #222;
 }
+
+.next-puzzle-button {
+  font-size: 3rem;
+  padding: 1.5rem 3rem;
+}


### PR DESCRIPTION
## Summary
- add a bigger `next-puzzle-button` CSS rule
- apply the new class to the "Next Puzzle" button

## Testing
- `npm test --silent` *(fails: No tests yet)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6a041348325a0ead9c9b661c009