### PR TITLE
Add puzzle rating system

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -51,3 +51,4 @@ class PuzzleDB(Base):
     id = Column(Integer, primary_key=True)
     fen = Column(String, nullable=False)
     moves = Column(String, nullable=False)
+    rating = Column(Integer, nullable=False, default=0)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -260,3 +260,17 @@ def list_performances(db: Session = Depends(get_db)):
         )
         for r in records
     ]
+
+
+@app.post("/api/puzzles/{puzzle_id}/rating", status_code=204)
+def rate_puzzle(puzzle_id: int, data: dict, db: Session = Depends(get_db)):
+    """Increase or decrease the rating of a puzzle."""
+    value = data.get("value")
+    if value not in (1, -1):
+        raise HTTPException(status_code=400, detail="value must be 1 or -1")
+    puzzle = db.query(PuzzleDB).filter(PuzzleDB.id == puzzle_id).first()
+    if not puzzle:
+        raise HTTPException(status_code=404, detail="puzzle not found")
+    puzzle.rating = (puzzle.rating or 0) + value
+    db.commit()
+    return

--- a/backend/build_thematic_sets.py
+++ b/backend/build_thematic_sets.py
@@ -82,12 +82,12 @@ def insert_puzzles(db: sqlite3.Connection, sets: dict[str, list[dict[str, Any]]]
             fen = row["FEN"]
             moves = row["Moves"]
             cur.execute(
-                "INSERT INTO puzzles (id, fen, moves) VALUES (?, ?, ?)",
+                "INSERT INTO puzzles (id, fen, moves, rating) VALUES (?, ?, ?, 0)",
                 (pid, fen, moves),
             )
             sql.append(
-                f"INSERT INTO puzzles (id, fen, moves) VALUES ({pid}, "
-                f"'{fen.replace("'", "''")}', '{moves}');"
+                f"INSERT INTO puzzles (id, fen, moves, rating) VALUES ({pid}, "
+                f"'{fen.replace("'", "''")}', '{moves}', 0);"
             )
             cur.execute(
                 "INSERT INTO puzzle_set_puzzles (puzzle_set_id, puzzle_id) VALUES (?, ?)",

--- a/backend/init_db.sql
+++ b/backend/init_db.sql
@@ -12,7 +12,8 @@ CREATE TABLE puzzle_sets (
 CREATE TABLE puzzles (
     id INTEGER PRIMARY KEY,
     fen TEXT NOT NULL,
-    moves TEXT NOT NULL
+    moves TEXT NOT NULL,
+    rating INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE puzzle_set_puzzles (
@@ -34,16 +35,16 @@ CREATE TABLE performances (
 INSERT INTO puzzle_sets (id, name, description) VALUES
 (1, 'Intro', 'Mate in one');
 
-INSERT INTO puzzles (id, fen, moves) VALUES
-(1, 'r5r1/pp2kp2/2p5/3pQ3/3P4/2NB4/PPP2q2/1K6 b - - 1 28', 'e7d7 d3f5 f2f5 e5f5'),
-(2, '8/5k2/1P4R1/6PK/1r6/8/8/8 w - - 1 58', 'h5h6 b4h4'),
-(3, '3r4/p5k1/1p1qprnp/1Q1pN1p1/3P1pP1/1PP5/P5PP/4RRK1 b - - 3 29', 'g6e5 d4e5 d6c5 b5c5 b6c5 e5f6'),
-(4, '6k1/3R3p/1p5q/3P4/3QP1pN/6P1/PPr3B1/5rK1 w - - 0 25', 'g1f1 h6c1 d4d1 c1d1'),
-(5, 'r5k1/1p1rqpp1/p3pnp1/2PN4/8/1Q5P/PP3PP1/3RR1K1 b - - 0 24', 'e7c5 d5f6 g7f6 d1d7'),
-(6, '8/6pk/7p/Q7/6P1/3q3K/1P5P/8 w - - 1 45', 'h3h4 g7g5 a5g5 h6g5'),
-(7, '8/2p1k3/6p1/1p1P1p2/1P3P2/3K2Pp/7P/8 b - - 1 43', 'e7d6 d3d4 g6g5 f4g5'),
-(8, '8/p7/2R3p1/4Nnk1/2P4p/7K/Pr6/8 b - - 3 50', 'g5f4 e5d3 f4g5 d3b2'),
-(9, 'r1b1k1nr/1pp2p2/p7/1B1q3p/6p1/4PP2/PPPQ1P2/2KR3R b kq - 1 17', 'd5b5 d2d8');
+INSERT INTO puzzles (id, fen, moves, rating) VALUES
+(1, 'r5r1/pp2kp2/2p5/3pQ3/3P4/2NB4/PPP2q2/1K6 b - - 1 28', 'e7d7 d3f5 f2f5 e5f5', 0),
+(2, '8/5k2/1P4R1/6PK/1r6/8/8/8 w - - 1 58', 'h5h6 b4h4', 0),
+(3, '3r4/p5k1/1p1qprnp/1Q1pN1p1/3P1pP1/1PP5/P5PP/4RRK1 b - - 3 29', 'g6e5 d4e5 d6c5 b5c5 b6c5 e5f6', 0),
+(4, '6k1/3R3p/1p5q/3P4/3QP1pN/6P1/PPr3B1/5rK1 w - - 0 25', 'g1f1 h6c1 d4d1 c1d1', 0),
+(5, 'r5k1/1p1rqpp1/p3pnp1/2PN4/8/1Q5P/PP3PP1/3RR1K1 b - - 0 24', 'e7c5 d5f6 g7f6 d1d7', 0),
+(6, '8/6pk/7p/Q7/6P1/3q3K/1P5P/8 w - - 1 45', 'h3h4 g7g5 a5g5 h6g5', 0),
+(7, '8/2p1k3/6p1/1p1P1p2/1P3P2/3K2Pp/7P/8 b - - 1 43', 'e7d6 d3d4 g6g5 f4g5', 0),
+(8, '8/p7/2R3p1/4Nnk1/2P4p/7K/Pr6/8 b - - 3 50', 'g5f4 e5d3 f4g5 d3b2', 0),
+(9, 'r1b1k1nr/1pp2p2/p7/1B1q3p/6p1/4PP2/PPPQ1P2/2KR3R b kq - 1 17', 'd5b5 d2d8', 0);
 
 INSERT INTO puzzle_set_puzzles (puzzle_set_id, puzzle_id) VALUES
 (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9);

--- a/docs/api_schema.md
+++ b/docs/api_schema.md
@@ -141,6 +141,20 @@ List stored session performances ordered from newest to oldest.
 ]
 ```
 
+### `POST /api/puzzles/{puzzle_id}/rating`
+Adjust the rating score of a puzzle. Positive values increase the rating while
+negative values decrease it.
+
+**Request body**
+```json
+{"value": 1}
+```
+
+`value` must be `1` or `-1`.
+
+**Response 204**
+
+
 ## Notes
 - All timestamps use ISO 8601 format (UTC).
 - Moves are in UCI format (`e2e4`). The frontend should convert from chessboard clicks to this format.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -174,6 +174,12 @@ function App() {
       }
   };
 
+  const ratePuzzle = async value => {
+    if (!puzzle) return;
+    await axios.post(`/api/puzzles/${puzzle.id}/rating`, { value });
+    await fetchNextPuzzle();
+  };
+
   const stepForward = () => {
     if (solutionIndex >= solutionMoves.length) return;
     const c = new Chess(chess.fen());
@@ -499,7 +505,13 @@ function App() {
               </>
             )}
             {(puzzleSolved || showSolution) && (
-              <button onClick={fetchNextPuzzle} style={{ marginTop: '1rem' }}>Next Puzzle</button>
+              <div style={{ marginTop: '1rem', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <button onClick={fetchNextPuzzle} style={{ marginBottom: '0.5rem' }}>Next Puzzle</button>
+                <div>
+                  <button onClick={() => ratePuzzle(1)}>Like</button>
+                  <button onClick={() => ratePuzzle(-1)} style={{ marginLeft: '0.5rem' }}>Dislike</button>
+                </div>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- store a `rating` score on puzzles
- allow incrementing or decrementing rating via new API endpoint
- update thematic set builder and database init script for rating column
- document rating endpoint
- add rating buttons in the UI

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fbf57fe548325a5fff53bae3ef95c