### PR TITLE
Fix pawn promotion handling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -153,7 +153,7 @@ def submit_move(session_id: str, move: MoveRequest):
     move_idx = session.get("move_index", 0)
     expected = solution[move_idx]
 
-    if move.move == expected:
+    if move.move.lower() == expected.lower():
         move_idx += 1
         next_move = None
         if move_idx == len(solution):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -235,14 +235,18 @@ function App() {
     return () => window.removeEventListener("keydown", handleEnter);
   }, [puzzleSolved, showSolution]);
 
-  const onDrop = async (sourceSquare, targetSquare) => {
+  const onDrop = async (sourceSquare, targetSquare, piece) => {
+    // Attempt the move, auto-promoting to a queen if necessary. The returned
+    // object will contain the promotion piece so we can send the full move
+    // (including promotion) to the backend.
     const move = chess.move({ from: sourceSquare, to: targetSquare, promotion: 'q' });
     if (move === null) return false;
     setChess(new Chess(chess.fen()));
     setLastMove({ from: sourceSquare, to: targetSquare });
     setHintSquare(null);
 
-    const res = await axios.post(`/api/sessions/${session}/move`, { move: `${sourceSquare}${targetSquare}` });
+    const promotion = move.promotion ? move.promotion : '';
+    const res = await axios.post(`/api/sessions/${session}/move`, { move: `${sourceSquare}${targetSquare}${promotion}` });
     setScore(res.data.score);
 
     if (!res.data.correct) {


### PR DESCRIPTION
## Summary
- ensure frontend sends promotion piece when performing move
- handle case-insensitive moves in backend

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fc4dbac6c83259d3c1d27b6dfc9d1